### PR TITLE
add hit check for ray along voxel

### DIFF
--- a/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -656,8 +656,9 @@ void btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans, co
 											  &tmpOb,
 											  resultCallback);
 
-						// Early out if hit - need to consider this (what if user wants to go deeper)
-						break;
+                        if(resultCallback.hasHit()) {
+                            break;
+						}
 					}
 
 					int next;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/854359/91689552-34287d80-eb19-11ea-9794-59b24f16e9c7.png)

This should resolve the fence ray problem in PR: https://github.com/MovingBlocks/Terasology/pull/4139

add hasHit check for rayTestSingleInternal. 